### PR TITLE
Add cache header for 10m per endpoint resolves #10

### DIFF
--- a/server/api/framedata/router.js
+++ b/server/api/framedata/router.js
@@ -9,12 +9,14 @@ module.exports = function($store) {
 
     router.get('/', (req, res) => {
         controller.getAllData()
+        .then( res.setHeader("Cache-Control", "public, max-age=600") )  // Cache endpoint via nginx for 10 minutes
         .then( data => res.json(data) )
         .catch( err => res.status(500).send(err) )
     })
 
     router.get('/:id', (req, res) => {
         controller.getCharacterData(req.params.id)
+        .then( res.setHeader("Cache-Control", "public, max-age=600") ) // Cache endpoint via nginx for 10 minutes
         .then( data => res.json(data) )
         .catch( err => res.status(500).send(err) )
     })

--- a/server/api/metadata/router.js
+++ b/server/api/metadata/router.js
@@ -8,7 +8,9 @@ module.exports = function($store) {
     let controller = new MetadataController($store)
 
     router.get('/', (req, res) => {
-        controller.getMetadata().then(data => {
+        controller.getMetadata()
+        .then( res.setHeader("Cache-Control", "public, max-age=600") ) // Cache endpoint via nginx for 10 minutes
+        .then(data => {
             res.json(data)
         }, err => {
             res.send(err)


### PR DESCRIPTION
I've added a cache header entry for each of our static (not relating to user login) endpoints.

This will tell nginx (and eventually our cdn) to cache the content for ~10m before it hits node.