### PR TITLE
Endpoint integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ADD package.json ./
 RUN npm install --production
 ADD ./server ./server
 
-EXPOSE 5000
-ENV PORT 5000
+EXPOSE 3000
+ENV PORT 3000
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8-alpine
+
+WORKDIR /app
+
+ADD package.json ./
+RUN npm install --production
+ADD ./server ./server
+
+EXPOSE 5000
+ENV PORT 5000
+CMD npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+
+version: '2'
+services:
+  web:
+    build:
+      context: .
+    ports:
+      - 5000:5000
+    depends_on:
+      - db
+    volumes:
+      - .:/app
+    environment:
+      DB_PASS: neverguess123
+      DB_USER: root
+      DB_HOST: db
+      NODE_ENV: development
+  db:
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: neverguess123
+      MYSQL_DATABASE: tekkenchicken
+    volumes:
+    - db:/var/lib/mysql
+
+volumes:
+  db: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
     ports:
-      - 5000:5000
+      - 3000:3000
     depends_on:
       - db
     volumes:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Tekken Chicken Web App Server",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha",
+    "test-routes": "mocha -R spec ./test/endpoints.test.js",
     "init": "node server/database/init.js",
     "update": "node server/database/update.js",
     "start": "node server/server.js"
@@ -22,6 +23,7 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "mocha": "^3.3.0"
+    "mocha": "^3.3.0",
+    "supertest": "^3.0.0"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -4,10 +4,12 @@ const PORT = process.env.PORT || 3000
 const bodyParser = require('body-parser')
 const api = require('./api')
 
-
 app.use(bodyParser.json())
 app.use('/api', api)
 
-app.listen(PORT, () => {
-    console.log(`Server listening on port ${PORT}`)
+const listener = app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`)
 })
+
+// export so we can do testing
+module.exports = { app, listener }

--- a/test-routes.sh
+++ b/test-routes.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if hash docker-compose 2>/dev/null; then
+    docker-compose rm -f db
+    docker volume prune -f
+    docker-compose up -d db
+    docker-compose run --rm web npm run init
+    docker-compose run --rm web npm run test-routes
+else
+    echo "Requires docker-compose to run the routing tests"
+fi

--- a/test/endpoints.test.js
+++ b/test/endpoints.test.js
@@ -1,0 +1,128 @@
+const request = require('supertest')
+const assert = require('assert')
+
+describe('loading express', () => {
+  let server
+  let close
+
+  beforeEach(() => {
+    const {app, listener} = require('../server/server')
+    server = app
+    close = listener.close.bind(listener)
+  })
+  afterEach(() => {
+    close()
+  })
+
+  it('responds to /api/framedata', () => {
+    const CHARACTER_KEYS = [
+      'josie',
+      'dragunov',
+      'akuma',
+      'devil-jin',
+      'gigas',
+      'kazumi',
+      'bryan',
+      'claudio',
+      'asuka',
+      'eliza',
+      'kazuya',
+      'king',
+      'jack-7',
+      'hwoarang',
+      'feng',
+      'katarina',
+      'bob',
+      'alisa',
+      'jin',
+      'eddy',
+      'leo',
+      'ling',
+      'lars',
+      'heihachi',
+      'law',
+      'lili',
+      'lee',
+      'lucky-chloe',
+      'nina',
+      'miguel',
+      'master-raven',
+      'shaheen',
+      'paul',
+      'steve',
+      'yoshimitsu'
+    ]
+    const ALISA_DATA = require('../server/database/json/t7-alisa-1.json')
+
+    return request(server).get('/api/framedata').then(res => {
+      assert(Object.keys(res.body), CHARACTER_KEYS)
+      assert(res.body.alisa.name, 'Alisa Bosconovich')
+      assert(res.body.alisa.label, 'alisa')
+      assert(res.body.alisa.data[0], ALISA_DATA.moves[0])
+    })
+  })
+
+  it('responds to /api/framedata/:id', () => {
+    const KAZUMI_DATA = require('../server/database/json/t7-kazumi-1.json')
+
+    return request(server).get(`/api/framedata/6`).then(res => {
+      assert(res.body.name, 'Kazumi Mishima')
+      assert(res.body.label, 'kazumi')
+      assert(res.body.data, KAZUMI_DATA.moves)
+    })
+  })
+
+  it('responds to /api/metadata', () => {
+    const KEYS = [
+      'josie',
+      'dragunov',
+      'akuma',
+      'devil-jin',
+      'gigas',
+      'kazumi',
+      'kuma',
+      'bryan',
+      'claudio',
+      'asuka',
+      'eliza',
+      'kazuya',
+      'king',
+      'jack-7',
+      'hwoarang',
+      'feng',
+      'katarina',
+      'bob',
+      'alisa',
+      'jin',
+      'eddy',
+      'leo',
+      'ling',
+      'lars',
+      'heihachi',
+      'law',
+      'lili',
+      'lee',
+      'lucky-chloe',
+      'nina',
+      'miguel',
+      'master-raven',
+      'shaheen',
+      'paul',
+      'steve',
+      'yoshimitsu',
+      'last_updated'
+    ]
+    const ENTRY_KEYS = [
+      'id',
+      'name',
+      'label',
+      'game',
+      'last_updated'
+    ]
+
+    return request(server).get(`/api/metadata`).then(res => {
+      assert(Object.keys(res.body), KEYS)
+      KEYS.slice(0,-1).forEach(k => assert(Object.keys(res.body[k]), ENTRY_KEYS))
+    })
+  })
+})


### PR DESCRIPTION
Also added docker harness to make it easier to reset the test env every time.

To run the tests, get docker and docker compose, then in the project directory:

```sh
$ docker-compose pull
$ docker-compose build
$ bash ./test-routes.sh
```

To retest, you just need to rerun `./test-routes.sh`